### PR TITLE
Change TakeScreenshot to SaveScreenshot (file-based)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ Tools follow the **resource + action enum** pattern (like mcp-server-excel):
 | `obs_scene` | List, GetCurrent, Set, ListSources |
 | `obs_source` | AddWindowCapture, ListWindows, SetWindowCapture, Remove, SetEnabled |
 | `obs_audio` | GetInputs, Mute, Unmute, GetMuteState, SetVolume, GetVolume, MuteAll, UnmuteAll |
-| `obs_media` | TakeScreenshot, StartVirtualCamera, StopVirtualCamera |
+| `obs_media` | SaveScreenshot, StartVirtualCamera, StopVirtualCamera |
 
 **Audio Note:** Recording starts with audio MUTED by default. Use `muteAudio=false` to include audio.
 
@@ -75,8 +75,20 @@ dotnet publish src/ObsMcp.McpServer -c Release -r win-x64 --self-contained -o vs
 ### Integration Tests
 - Require OBS Studio running with WebSocket enabled
 - Configure `.env` file with `OBS_PASSWORD`
-- Located in `tests/ObsMcp.McpServer.Tests/IntegrationTests.cs`
-- Will auto-start OBS if not running
+- Located in `tests/ObsMcp.McpServer.Tests/McpServerIntegrationTests.cs`
+- **MUST fail if OBS is not running** - never silently skip or return early
+- Mark with `[Trait("Category", "Integration")]`
+
+### Test Requirements
+- **Integration tests MUST fail clearly** if prerequisites (like OBS) are not available
+- Never use `return;` to skip tests silently - use proper assertions that fail
+- All tests must have clear failure messages explaining what went wrong
+
+## Git Workflow
+
+- **Never commit or push without explicit user consent**
+- Always ask before running `git commit` or `git push`
+- Create issues and PRs for changes - do not commit directly to main
 
 ## Code Style
 

--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -87,7 +87,7 @@ jobs:
         | obs_scene | List, GetCurrent, Set, ListSources |
         | obs_source | AddWindowCapture, ListWindows, SetWindowCapture, Remove, SetEnabled |
         | obs_audio | GetInputs, Mute, Unmute, GetMuteState, SetVolume, GetVolume, MuteAll, UnmuteAll |
-        | obs_media | TakeScreenshot, StartVirtualCamera, StopVirtualCamera |
+        | obs_media | SaveScreenshot, StartVirtualCamera, StopVirtualCamera |
         
         > **Note:** Recording starts with audio **muted** by default. Use muteAudio=false to include audio.
         

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,10 @@
 		"dist": true // set this to false to include "dist" folder in search results
 	},
 	// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-	"typescript.tsc.autoDetect": "off"
+	"typescript.tsc.autoDetect": "off",
+	"cSpell.words": [
+		"Sbroenne",
+		"Unmute",
+		"Xunit"
+	]
 }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,20 @@ Control OBS Studio through AI assistants (GitHub Copilot, Claude, etc.):
 
 ## Installation
 
-### Option 1: Standalone MCP Server (Any MCP Client)
+### VS Code / VS Code Insiders (Recommended)
+
+Install directly from the VS Code Marketplace:
+
+[![Install in VS Code](https://img.shields.io/badge/VS%20Code-Install%20Extension-blue?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=sbroenne.obs-mcp-server)
+
+1. Open VS Code
+2. Go to Extensions (`Ctrl+Shift+X`)
+3. Search for **"OBS Studio MCP Server"**
+4. Click **Install**
+
+Or run: `code --install-extension sbroenne.obs-mcp-server`
+
+### Other MCP Clients (Claude Desktop, Cursor, Windsurf, etc.)
 
 Download from [GitHub Releases](https://github.com/sbroenne/mcp-server-obs/releases):
 
@@ -70,15 +83,8 @@ Extract and add to your MCP client config:
 | Client | Path |
 |--------|------|
 | Claude Desktop | `%APPDATA%\Claude\claude_desktop_config.json` |
-| VS Code | `.vscode/mcp.json` in workspace |
 | Cursor | `~/.cursor/mcp.json` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
-
-### Option 2: VS Code Extension
-
-Search for "OBS Studio MCP Server" in VS Code Extensions and click Install.
-
-Or download `.vsix` from [GitHub Releases](https://github.com/sbroenne/mcp-server-obs/releases).
 
 ## Prerequisites
 
@@ -103,7 +109,7 @@ Or download `.vsix` from [GitHub Releases](https://github.com/sbroenne/mcp-serve
 | `obs_scene` | List, GetCurrent, Set, ListSources |
 | `obs_source` | AddWindowCapture, ListWindows, SetWindowCapture, Remove, SetEnabled |
 | `obs_audio` | GetInputs, Mute, Unmute, GetMuteState, SetVolume, GetVolume, MuteAll, UnmuteAll |
-| `obs_media` | TakeScreenshot, StartVirtualCamera, StopVirtualCamera |
+| `obs_media` | SaveScreenshot, StartVirtualCamera, StopVirtualCamera |
 
 > **Note:** Recording starts with audio **muted** by default. Use `muteAudio=false` to include audio.
 

--- a/scripts/install-hooks.ps1
+++ b/scripts/install-hooks.ps1
@@ -1,0 +1,16 @@
+# Install pre-commit hook
+# Run from project root: .\scripts\install-hooks.ps1
+
+$hookSource = Join-Path $PSScriptRoot "pre-commit"
+$hookDest = Join-Path $PSScriptRoot "..\\.git\\hooks\\pre-commit"
+
+if (-not (Test-Path (Split-Path $hookDest))) {
+    Write-Host "Creating hooks directory..."
+    New-Item -ItemType Directory -Path (Split-Path $hookDest) -Force | Out-Null
+}
+
+Copy-Item $hookSource $hookDest -Force
+Write-Host "✅ Pre-commit hook installed to .git/hooks/pre-commit" -ForegroundColor Green
+Write-Host ""
+Write-Host "The hook will run 'dotnet test' before each commit."
+Write-Host "To bypass (not recommended): git commit --no-verify"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Pre-commit hook that runs all tests before allowing a commit.
+# Install with: cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+
+echo "🧪 Running tests before commit..."
+echo ""
+
+# Load .env file if it exists (for OBS_PASSWORD)
+if [ -f .env ]; then
+    export $(cat .env | grep -v '^#' | xargs)
+fi
+
+# Run all tests
+dotnet test --verbosity minimal
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "❌ Tests failed. Commit aborted."
+    echo ""
+    echo "To skip this check (not recommended), use: git commit --no-verify"
+    exit 1
+fi
+
+echo ""
+echo "✅ All tests passed. Proceeding with commit."
+exit 0

--- a/scripts/pre-commit.ps1
+++ b/scripts/pre-commit.ps1
@@ -1,0 +1,31 @@
+# Pre-commit hook that runs all tests before allowing a commit.
+# Install with: Copy-Item scripts\pre-commit.ps1 .git\hooks\pre-commit.ps1
+
+Write-Host "🧪 Running tests before commit..." -ForegroundColor Cyan
+Write-Host ""
+
+# Load .env file if it exists
+$envFile = Join-Path $PSScriptRoot "..\..\\.env"
+if (Test-Path $envFile) {
+    Get-Content $envFile | ForEach-Object {
+        if ($_ -match '^([^#][^=]+)=(.*)$') {
+            [Environment]::SetEnvironmentVariable($matches[1], $matches[2], 'Process')
+        }
+    }
+}
+
+# Run all tests
+$result = dotnet test --verbosity minimal
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne 0) {
+    Write-Host ""
+    Write-Host "❌ Tests failed. Commit aborted." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "To skip this check (not recommended), use: git commit --no-verify" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host ""
+Write-Host "✅ All tests passed. Proceeding with commit." -ForegroundColor Green
+exit 0

--- a/src/ObsMcp.McpServer/ObsClient.cs
+++ b/src/ObsMcp.McpServer/ObsClient.cs
@@ -65,7 +65,7 @@ public class ObsClient : IDisposable
 
     // Recording operations
     public void StartRecording() => _obs.StartRecord();
-    public void StopRecording() => _obs.StopRecord();
+    public string StopRecording() => _obs.StopRecord();
     public void PauseRecording() => _obs.PauseRecord();
     public void ResumeRecording() => _obs.ResumeRecord();
 
@@ -259,16 +259,17 @@ public class ObsClient : IDisposable
         }
     }
 
-    // Screenshot
-    public string TakeScreenshot(string? sourceName, string imageFormat, int? width, int? height)
+    // Screenshot - saves to file
+    public void SaveScreenshot(string filePath, string? sourceName, string imageFormat, int? width, int? height, int? quality)
     {
         var scene = sourceName ?? GetCurrentScene();
         // Use -1 to indicate source resolution (OBS default)
         var w = width ?? -1;
         var h = height ?? -1;
+        var q = quality ?? -1;
 
-        // Use GetSourceScreenshot which returns base64 data
-        return _obs.GetSourceScreenshot(scene, imageFormat, w, h, -1);
+        // Use SaveSourceScreenshot which saves directly to file
+        _obs.SaveSourceScreenshot(scene, imageFormat, filePath, w, h, q);
     }
 
     // Virtual camera

--- a/src/ObsMcp.McpServer/Program.cs
+++ b/src/ObsMcp.McpServer/Program.cs
@@ -51,7 +51,7 @@ public static class Program
             - `obs_scene` - List, GetCurrent, Set, ListSources
             - `obs_source` - AddWindowCapture, ListWindows, SetWindowCapture, Remove, SetEnabled
             - `obs_audio` - GetInputs, Mute, Unmute, GetMuteState, SetVolume, GetVolume, MuteAll, UnmuteAll
-            - `obs_media` - TakeScreenshot, StartVirtualCamera, StopVirtualCamera
+            - `obs_media` - SaveScreenshot, StartVirtualCamera, StopVirtualCamera
             
             ## IMPORTANT: Audio is MUTED by Default
             

--- a/src/ObsMcp.McpServer/README.md
+++ b/src/ObsMcp.McpServer/README.md
@@ -155,7 +155,7 @@ The server provides 6 resource-based tools with action enums:
 | `obs_streaming` | `Start`, `Stop`, `GetStatus` | Streaming control |
 | `obs_scene` | `List`, `GetCurrent`, `Set`, `ListSources` | Scene management |
 | `obs_source` | `AddWindowCapture`, `ListWindows`, `SetWindowCapture`, `Remove`, `SetEnabled` | Source management |
-| `obs_media` | `TakeScreenshot`, `StartVirtualCamera`, `StopVirtualCamera` | Media operations |
+| `obs_media` | `SaveScreenshot`, `StartVirtualCamera`, `StopVirtualCamera` | Media operations |
 
 ## Window Capture Workflow
 
@@ -213,7 +213,7 @@ ObsMcp.McpServer/
 │   ├── ObsStreamingTool.cs    # obs_streaming tool (Start, Stop, GetStatus)
 │   ├── ObsSceneTool.cs        # obs_scene tool (List, GetCurrent, Set, ListSources)
 │   ├── ObsSourceTool.cs       # obs_source tool (AddWindowCapture, ListWindows, etc.)
-│   └── ObsMediaTool.cs        # obs_media tool (TakeScreenshot, VirtualCamera)
+│   └── ObsMediaTool.cs        # obs_media tool (SaveScreenshot, VirtualCamera)
 └── README.md                  # This file
 ```
 

--- a/src/ObsMcp.McpServer/Tools/ObsRecordingTool.cs
+++ b/src/ObsMcp.McpServer/Tools/ObsRecordingTool.cs
@@ -125,8 +125,8 @@ public static partial class ObsRecordingTool
     private static string DoStop()
     {
         var client = ObsConnectionTool.GetClient();
-        client.StopRecording();
-        return "Recording stopped and saved";
+        var outputPath = client.StopRecording();
+        return $"Recording stopped and saved to: {outputPath}";
     }
 
     private static string DoPause()

--- a/tests/ObsMcp.McpServer.Tests/ObsIntegrationTests.cs
+++ b/tests/ObsMcp.McpServer.Tests/ObsIntegrationTests.cs
@@ -1,0 +1,614 @@
+using System.IO.Pipelines;
+using DotNetEnv;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Sbroenne.ObsMcp.McpServer.Tools;
+using Xunit;
+using Xunit.Abstractions;
+
+using Server = ModelContextProtocol.Server;
+
+namespace Sbroenne.ObsMcp.McpServer.Tests;
+
+/// <summary>
+/// Integration tests that require OBS Studio to be running with WebSocket enabled.
+/// These tests exercise the full tool chain: MCP client -> MCP server -> OBS WebSocket -> OBS.
+/// 
+/// Prerequisites:
+/// - OBS Studio running with WebSocket server enabled (port 4455)
+/// - .env file with OBS_PASSWORD set
+/// 
+/// Run with: dotnet test --filter "Category=Integration"
+/// </summary>
+[Trait("Category", "Integration")]
+public class ObsIntegrationTests : IAsyncLifetime, IAsyncDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly Pipe _clientToServerPipe = new();
+    private readonly Pipe _serverToClientPipe = new();
+    private readonly CancellationTokenSource _cts = new();
+    private Server.McpServer? _server;
+    private McpClient? _client;
+    private IServiceProvider? _serviceProvider;
+    private Task? _serverTask;
+
+    static ObsIntegrationTests()
+    {
+        Env.TraversePath().Load();
+    }
+
+    public ObsIntegrationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.AddDebug().SetMinimumLevel(LogLevel.Debug));
+
+        services
+            .AddMcpServer(options =>
+            {
+                options.ServerInfo = new() { Name = "obs-mcp-server-test", Version = "1.0.0" };
+            })
+            .WithStreamServerTransport(
+                _clientToServerPipe.Reader.AsStream(),
+                _serverToClientPipe.Writer.AsStream())
+            .WithToolsFromAssembly(typeof(ObsConnectionTool).Assembly);
+
+        _serviceProvider = services.BuildServiceProvider(validateScopes: true);
+        _server = _serviceProvider.GetRequiredService<Server.McpServer>();
+        _serverTask = _server.RunAsync(_cts.Token);
+
+        _client = await McpClient.CreateAsync(
+            new StreamClientTransport(
+                serverInput: _clientToServerPipe.Writer.AsStream(),
+                serverOutput: _serverToClientPipe.Reader.AsStream()),
+            clientOptions: new McpClientOptions
+            {
+                ClientInfo = new() { Name = "IntegrationTestClient", Version = "1.0.0" }
+            },
+            cancellationToken: _cts.Token);
+
+        // Connect to OBS at the start of each test
+        await ConnectToObs();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await DisposeAsyncCore();
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        await DisposeAsyncCore();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task DisposeAsyncCore()
+    {
+        // Disconnect from OBS
+        try
+        {
+            await CallToolAsync("obs_connection", new() { ["action"] = "Disconnect" });
+        }
+        catch { /* Ignore cleanup errors */ }
+
+        await _cts.CancelAsync();
+        _clientToServerPipe.Writer.Complete();
+        _serverToClientPipe.Writer.Complete();
+
+        if (_client != null) await _client.DisposeAsync();
+        if (_serverTask != null)
+        {
+            try { await _serverTask; }
+            catch (OperationCanceledException) { }
+        }
+        if (_serviceProvider is IAsyncDisposable ad) await ad.DisposeAsync();
+        else if (_serviceProvider is IDisposable d) d.Dispose();
+        _cts.Dispose();
+    }
+
+    private async Task ConnectToObs()
+    {
+        var password = Environment.GetEnvironmentVariable("OBS_PASSWORD") ?? "";
+        var result = await CallToolAsync("obs_connection", new()
+        {
+            ["action"] = "Connect",
+            ["host"] = "localhost",
+            ["port"] = 4455,
+            ["password"] = password
+        });
+
+        Assert.DoesNotContain("Error", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Connected to OBS", result);
+        _output.WriteLine($"✓ Connected to OBS: {result}");
+    }
+
+    private async Task<string> CallToolAsync(string toolName, Dictionary<string, object?> args)
+    {
+        var result = await _client!.CallToolAsync(toolName, args, cancellationToken: _cts.Token);
+        var textBlock = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        return textBlock?.Text ?? "";
+    }
+
+    #region obs_connection Tests
+
+    [Fact]
+    public async Task Connection_GetStatus_ReturnsConnected()
+    {
+        var result = await CallToolAsync("obs_connection", new() { ["action"] = "GetStatus" });
+
+        _output.WriteLine($"GetStatus result: {result}");
+        Assert.Contains("Connected", result);
+    }
+
+    [Fact]
+    public async Task Connection_GetStats_ReturnsPerformanceData()
+    {
+        var result = await CallToolAsync("obs_connection", new() { ["action"] = "GetStats" });
+
+        _output.WriteLine($"GetStats result: {result}");
+        Assert.Contains("FPS", result);
+        Assert.Contains("CPU Usage", result);
+    }
+
+    #endregion
+
+    #region obs_scene Tests
+
+    [Fact]
+    public async Task Scene_List_ReturnsScenes()
+    {
+        var result = await CallToolAsync("obs_scene", new() { ["action"] = "List" });
+
+        _output.WriteLine($"Scene List result: {result}");
+        // OBS always has at least one scene
+        Assert.DoesNotContain("Error", result);
+    }
+
+    [Fact]
+    public async Task Scene_GetCurrent_ReturnsCurrentScene()
+    {
+        var result = await CallToolAsync("obs_scene", new() { ["action"] = "GetCurrent" });
+
+        _output.WriteLine($"GetCurrent result: {result}");
+        Assert.DoesNotContain("Error", result);
+        // Should return a scene name
+        Assert.False(string.IsNullOrWhiteSpace(result));
+    }
+
+    [Fact]
+    public async Task Scene_ListSources_ReturnsSources()
+    {
+        var result = await CallToolAsync("obs_scene", new() { ["action"] = "ListSources" });
+
+        _output.WriteLine($"ListSources result: {result}");
+        Assert.DoesNotContain("Error", result);
+    }
+
+    #endregion
+
+    #region obs_recording Tests
+
+    [Fact]
+    public async Task Recording_GetStatus_ReturnsStatus()
+    {
+        var result = await CallToolAsync("obs_recording", new() { ["action"] = "GetStatus" });
+
+        _output.WriteLine($"Recording GetStatus result: {result}");
+        Assert.Contains("Active:", result);
+    }
+
+    [Fact]
+    public async Task Recording_GetSettings_ReturnsSettings()
+    {
+        var result = await CallToolAsync("obs_recording", new() { ["action"] = "GetSettings" });
+
+        _output.WriteLine($"Recording GetSettings result: {result}");
+        Assert.DoesNotContain("Error", result);
+    }
+
+    [Fact]
+    public async Task Recording_GetPath_ReturnsPath()
+    {
+        var result = await CallToolAsync("obs_recording", new() { ["action"] = "GetPath" });
+
+        _output.WriteLine($"Recording GetPath result: {result}");
+        Assert.DoesNotContain("Error", result);
+    }
+
+    [Fact]
+    public async Task Recording_StartStopCycle_CreatesFile()
+    {
+        // Start recording
+        var startResult = await CallToolAsync("obs_recording", new() { ["action"] = "Start" });
+        _output.WriteLine($"Start result: {startResult}");
+        Assert.DoesNotContain("Error", startResult);
+
+        // Wait for some content to be recorded (3 seconds for reliable file creation)
+        await Task.Delay(3000);
+
+        // Check status
+        var statusResult = await CallToolAsync("obs_recording", new() { ["action"] = "GetStatus" });
+        _output.WriteLine($"Status during recording: {statusResult}");
+        Assert.Contains("Active: True", statusResult);
+
+        // Stop recording - should return file path
+        var stopResult = await CallToolAsync("obs_recording", new() { ["action"] = "Stop" });
+        _output.WriteLine($"Stop result: {stopResult}");
+        Assert.DoesNotContain("Error", stopResult);
+        Assert.Contains("saved to:", stopResult);
+
+        // Extract file path from result (OBS returns forward slashes on Windows)
+        var match = System.Text.RegularExpressions.Regex.Match(stopResult, @"saved to: (.+)$");
+        Assert.True(match.Success, $"Could not extract file path from: {stopResult}");
+        
+        var filePath = match.Groups[1].Value.Trim().Replace('/', '\\');
+        _output.WriteLine($"Recording file path: {filePath}");
+
+        // Wait for OBS to finalize the file (MP4/MKV write metadata at the end)
+        // OBS takes 2-3 seconds to finalize the file after stop returns
+        // Retry up to 10 times with 500ms delay (5 seconds total)
+        long fileSize = 0;
+        for (int i = 0; i < 10; i++)
+        {
+            await Task.Delay(500);
+            if (File.Exists(filePath))
+            {
+                // Must create a new FileInfo each time to get fresh file size
+                // (FileInfo.Refresh doesn't always work for newly written files)
+                fileSize = new FileInfo(filePath).Length;
+                _output.WriteLine($"Attempt {i + 1}: file size = {fileSize} bytes");
+                if (fileSize > 0) break;
+            }
+            else
+            {
+                _output.WriteLine($"Attempt {i + 1}: file not found yet");
+            }
+        }
+
+        // Verify file exists
+        Assert.True(File.Exists(filePath), $"Recording file not created at {filePath}");
+
+        // Verify file has content
+        Assert.True(fileSize > 0, $"Recording file is empty (0 bytes) at {filePath}");
+        _output.WriteLine($"✓ Recording file created: {fileSize} bytes");
+
+        // Clean up test file
+        File.Delete(filePath);
+        _output.WriteLine("✓ Test recording file cleaned up");
+    }
+
+    [Fact]
+    public async Task Recording_PauseResumeCycle_Works()
+    {
+        // Start recording first
+        await CallToolAsync("obs_recording", new() { ["action"] = "Start" });
+        await Task.Delay(500);
+
+        try
+        {
+            // Pause
+            var pauseResult = await CallToolAsync("obs_recording", new() { ["action"] = "Pause" });
+            _output.WriteLine($"Pause result: {pauseResult}");
+            Assert.DoesNotContain("Error", pauseResult);
+
+            // Check paused status
+            var statusResult = await CallToolAsync("obs_recording", new() { ["action"] = "GetStatus" });
+            _output.WriteLine($"Status while paused: {statusResult}");
+            Assert.Contains("Paused: True", statusResult);
+
+            // Resume
+            var resumeResult = await CallToolAsync("obs_recording", new() { ["action"] = "Resume" });
+            _output.WriteLine($"Resume result: {resumeResult}");
+            Assert.DoesNotContain("Error", resumeResult);
+        }
+        finally
+        {
+            // Always stop recording
+            await CallToolAsync("obs_recording", new() { ["action"] = "Stop" });
+        }
+    }
+
+    #endregion
+
+    #region obs_streaming Tests
+
+    [Fact]
+    public async Task Streaming_GetStatus_ReturnsStatus()
+    {
+        var result = await CallToolAsync("obs_streaming", new() { ["action"] = "GetStatus" });
+
+        _output.WriteLine($"Streaming GetStatus result: {result}");
+        Assert.Contains("Active:", result);
+    }
+
+    // Note: Start/Stop streaming tests are skipped because they require a configured stream destination
+
+    #endregion
+
+    #region obs_audio Tests
+
+    [Fact]
+    public async Task Audio_GetInputs_ReturnsInputs()
+    {
+        var result = await CallToolAsync("obs_audio", new() { ["action"] = "GetInputs" });
+
+        _output.WriteLine($"Audio GetInputs result: {result}");
+        Assert.DoesNotContain("Error", result);
+    }
+
+    [Fact]
+    public async Task Audio_MuteUnmuteCycle_Works()
+    {
+        // Get inputs first to find one to test with
+        var inputsResult = await CallToolAsync("obs_audio", new() { ["action"] = "GetInputs" });
+        _output.WriteLine($"Inputs: {inputsResult}");
+
+        // Try with Desktop Audio (common default)
+        var testInput = "Desktop Audio";
+
+        // Get initial mute state
+        var initialState = await CallToolAsync("obs_audio", new()
+        {
+            ["action"] = "GetMuteState",
+            ["inputName"] = testInput
+        });
+        _output.WriteLine($"Initial mute state: {initialState}");
+
+        if (initialState.Contains("Error"))
+        {
+            _output.WriteLine("Desktop Audio not found, skipping mute test");
+            return;
+        }
+
+        // Mute
+        var muteResult = await CallToolAsync("obs_audio", new()
+        {
+            ["action"] = "Mute",
+            ["inputName"] = testInput
+        });
+        _output.WriteLine($"Mute result: {muteResult}");
+        Assert.DoesNotContain("Error", muteResult);
+
+        // Verify muted
+        var mutedState = await CallToolAsync("obs_audio", new()
+        {
+            ["action"] = "GetMuteState",
+            ["inputName"] = testInput
+        });
+        Assert.Contains("muted", mutedState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("unmuted", mutedState, StringComparison.OrdinalIgnoreCase);
+
+        // Unmute
+        var unmuteResult = await CallToolAsync("obs_audio", new()
+        {
+            ["action"] = "Unmute",
+            ["inputName"] = testInput
+        });
+        _output.WriteLine($"Unmute result: {unmuteResult}");
+        Assert.DoesNotContain("Error", unmuteResult);
+    }
+
+    [Fact]
+    public async Task Audio_GetSetVolume_Works()
+    {
+        var testInput = "Desktop Audio";
+
+        // Get current volume
+        var getResult = await CallToolAsync("obs_audio", new()
+        {
+            ["action"] = "GetVolume",
+            ["inputName"] = testInput
+        });
+        _output.WriteLine($"GetVolume result: {getResult}");
+
+        if (getResult.Contains("Error"))
+        {
+            _output.WriteLine("Desktop Audio not found, skipping volume test");
+            return;
+        }
+
+        // Set volume to 0.5
+        var setResult = await CallToolAsync("obs_audio", new()
+        {
+            ["action"] = "SetVolume",
+            ["inputName"] = testInput,
+            ["volume"] = 0.5
+        });
+        _output.WriteLine($"SetVolume result: {setResult}");
+        Assert.DoesNotContain("Error", setResult);
+
+        // Verify volume changed
+        var verifyResult = await CallToolAsync("obs_audio", new()
+        {
+            ["action"] = "GetVolume",
+            ["inputName"] = testInput
+        });
+        _output.WriteLine($"Verify volume: {verifyResult}");
+    }
+
+    [Fact]
+    public async Task Audio_MuteAllUnmuteAll_Works()
+    {
+        // Mute all
+        var muteAllResult = await CallToolAsync("obs_audio", new() { ["action"] = "MuteAll" });
+        _output.WriteLine($"MuteAll result: {muteAllResult}");
+        Assert.DoesNotContain("Error", muteAllResult);
+
+        // Unmute all
+        var unmuteAllResult = await CallToolAsync("obs_audio", new() { ["action"] = "UnmuteAll" });
+        _output.WriteLine($"UnmuteAll result: {unmuteAllResult}");
+        Assert.DoesNotContain("Error", unmuteAllResult);
+    }
+
+    #endregion
+
+    #region obs_source Tests
+
+    [Fact]
+    public async Task Source_AddAndRemoveWindowCapture_Works()
+    {
+        var sourceName = $"Test_Window_Capture_{Guid.NewGuid():N}";
+
+        try
+        {
+            // Add window capture
+            var addResult = await CallToolAsync("obs_source", new()
+            {
+                ["action"] = "AddWindowCapture",
+                ["sourceName"] = sourceName
+            });
+            _output.WriteLine($"AddWindowCapture result: {addResult}");
+            Assert.DoesNotContain("Error", addResult);
+
+            // List windows
+            var listResult = await CallToolAsync("obs_source", new()
+            {
+                ["action"] = "ListWindows",
+                ["sourceName"] = sourceName
+            });
+            _output.WriteLine($"ListWindows result: {listResult}");
+            Assert.DoesNotContain("Error", listResult);
+
+            // Verify source is in scene
+            var sceneSources = await CallToolAsync("obs_scene", new() { ["action"] = "ListSources" });
+            Assert.Contains(sourceName, sceneSources);
+        }
+        finally
+        {
+            // Clean up - remove the source
+            var removeResult = await CallToolAsync("obs_source", new()
+            {
+                ["action"] = "Remove",
+                ["sourceName"] = sourceName
+            });
+            _output.WriteLine($"Remove result: {removeResult}");
+        }
+    }
+
+    [Fact]
+    public async Task Source_SetEnabled_Works()
+    {
+        var sourceName = $"Test_Source_{Guid.NewGuid():N}";
+
+        try
+        {
+            // Add a source first
+            await CallToolAsync("obs_source", new()
+            {
+                ["action"] = "AddWindowCapture",
+                ["sourceName"] = sourceName
+            });
+
+            // Disable
+            var disableResult = await CallToolAsync("obs_source", new()
+            {
+                ["action"] = "SetEnabled",
+                ["sourceName"] = sourceName,
+                ["enabled"] = false
+            });
+            _output.WriteLine($"Disable result: {disableResult}");
+            Assert.DoesNotContain("Error", disableResult);
+
+            // Enable
+            var enableResult = await CallToolAsync("obs_source", new()
+            {
+                ["action"] = "SetEnabled",
+                ["sourceName"] = sourceName,
+                ["enabled"] = true
+            });
+            _output.WriteLine($"Enable result: {enableResult}");
+            Assert.DoesNotContain("Error", enableResult);
+        }
+        finally
+        {
+            await CallToolAsync("obs_source", new()
+            {
+                ["action"] = "Remove",
+                ["sourceName"] = sourceName
+            });
+        }
+    }
+
+    #endregion
+
+    #region obs_media Tests
+
+    [Fact]
+    public async Task Media_SaveScreenshot_SavesFile()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"obs_test_{Guid.NewGuid()}.png");
+
+        try
+        {
+            var result = await CallToolAsync("obs_media", new()
+            {
+                ["action"] = "SaveScreenshot",
+                ["filePath"] = tempPath
+            });
+
+            _output.WriteLine($"SaveScreenshot result: {result}");
+            Assert.Contains("Screenshot saved to", result);
+            Assert.True(File.Exists(tempPath), $"Screenshot file not created at {tempPath}");
+
+            var fileInfo = new FileInfo(tempPath);
+            Assert.True(fileInfo.Length > 0, "Screenshot file is empty");
+            _output.WriteLine($"✓ Screenshot saved: {fileInfo.Length} bytes");
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task Media_SaveScreenshot_SupportsJpgWithQuality()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"obs_test_{Guid.NewGuid()}.jpg");
+
+        try
+        {
+            var result = await CallToolAsync("obs_media", new()
+            {
+                ["action"] = "SaveScreenshot",
+                ["filePath"] = tempPath,
+                ["quality"] = 80
+            });
+
+            _output.WriteLine($"SaveScreenshot JPG result: {result}");
+            Assert.Contains("Screenshot saved to", result);
+            Assert.True(File.Exists(tempPath), $"JPG screenshot not created at {tempPath}");
+
+            var fileInfo = new FileInfo(tempPath);
+            Assert.True(fileInfo.Length > 0, "JPG screenshot file is empty");
+            _output.WriteLine($"✓ JPG screenshot saved: {fileInfo.Length} bytes");
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task Media_VirtualCamera_StartStop_Works()
+    {
+        // Start virtual camera
+        var startResult = await CallToolAsync("obs_media", new() { ["action"] = "StartVirtualCamera" });
+        _output.WriteLine($"StartVirtualCamera result: {startResult}");
+        Assert.DoesNotContain("Error", startResult);
+
+        await Task.Delay(500);
+
+        // Stop virtual camera
+        var stopResult = await CallToolAsync("obs_media", new() { ["action"] = "StopVirtualCamera" });
+        _output.WriteLine($"StopVirtualCamera result: {stopResult}");
+        Assert.DoesNotContain("Error", stopResult);
+    }
+
+    #endregion
+}

--- a/vscode-extension/.github/copilot-instructions.md
+++ b/vscode-extension/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ This MCP server controls OBS Studio for screen recording and streaming.
 | `obs_streaming` | Start, Stop, GetStatus |
 | `obs_scene` | List, GetCurrent, Set, ListSources |
 | `obs_source` | AddWindowCapture, ListWindows, SetWindowCapture, Remove, SetEnabled |
-| `obs_media` | TakeScreenshot, StartVirtualCamera, StopVirtualCamera |
+| `obs_media` | SaveScreenshot, StartVirtualCamera, StopVirtualCamera |
 
 ## CRITICAL: Prevent Black Screen Recordings
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -7,7 +7,7 @@ Control OBS Studio recordings, streaming, and scenes directly from VS Code using
 - **Zero Configuration** - Automatically registers the OBS MCP server with VS Code
 - **Full OBS Control** - Manage recordings, streaming, scenes, and sources
 - **Window Capture** - Programmatically select which window to record
-- **Screenshot Support** - Capture screenshots of scenes or sources
+- **Screenshot Support** - Save screenshots of scenes or sources to files
 - **Virtual Camera** - Control OBS virtual camera
 
 ## Requirements
@@ -19,36 +19,23 @@ Control OBS Studio recordings, streaming, and scenes directly from VS Code using
 
 ## Installation
 
-### Option 1: VS Code Marketplace
-Search for "OBS MCP Server" in the VS Code Extensions view and click Install.
+### VS Code Marketplace (Recommended)
 
-### Option 2: Install from VSIX (Local Development)
+[![Install in VS Code](https://img.shields.io/badge/VS%20Code-Install%20Extension-blue?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=sbroenne.obs-mcp-server)
 
-1. Download the `.vsix` file from [GitHub Releases](https://github.com/sbroenne/mcp-server-obs/releases) or build locally
+1. Open VS Code
+2. Go to Extensions (`Ctrl+Shift+X`)
+3. Search for **"OBS Studio MCP Server"**
+4. Click **Install**
+
+Or run: `code --install-extension sbroenne.obs-mcp-server`
+
+### Install from VSIX (Manual)
+
+1. Download the `.vsix` file from [GitHub Releases](https://github.com/sbroenne/mcp-server-obs/releases)
 2. In VS Code, open the Command Palette (`Ctrl+Shift+P`)
 3. Run **Extensions: Install from VSIX...**
 4. Select the downloaded `.vsix` file
-
-Or install via command line:
-```powershell
-code --install-extension obs-mcp-0.0.3.vsix
-```
-
-### Option 3: Build from Source
-
-```powershell
-# Clone the repository
-git clone https://github.com/sbroenne/mcp-server-obs.git
-cd mcp-server-obs
-
-# Build the .NET MCP server and VS Code extension
-cd vscode-extension
-npm install
-npm run package
-
-# Install the extension
-code --install-extension obs-mcp-0.0.3.vsix
-```
 
 ## Setup
 
@@ -108,7 +95,7 @@ Once connected, the following tools are available to AI assistants:
 - `obs_set_source_enabled` - Show/hide a source
 
 ### Media
-- `obs_take_screenshot` - Take a screenshot
+- `obs_save_screenshot` - Save a screenshot to a file
 - `obs_start_virtual_camera` - Start virtual camera
 - `obs_stop_virtual_camera` - Stop virtual camera
 
@@ -119,7 +106,7 @@ In Copilot Chat, try:
 - "Connect to OBS and start recording"
 - "Add a window capture of VS Code"
 - "List all available windows and capture Chrome"
-- "Take a screenshot of the current scene"
+- "Save a screenshot of the current scene to C:/Screenshots/capture.png"
 - "Switch to scene 'Gaming' and start streaming"
 
 ## Troubleshooting


### PR DESCRIPTION
Fixes #2

## Summary

LLMs report they cannot read the base64 screenshot data returned by the current TakeScreenshot action. This PR changes screenshots to save directly to a file path specified by the LLM.

## Changes

### Core Screenshot Changes
- Rename `TakeScreenshot` action to `SaveScreenshot`
- Use OBS `SaveSourceScreenshot` API instead of `GetSourceScreenshot`
- Add required `filePath` parameter (e.g., `C:/Screenshots/capture.png`)
- Add optional `quality` parameter for JPG compression (1-100)
- Auto-create directory if it doesn't exist
- Infer format from file extension if not specified

### Recording Enhancement
- `StopRecording` now returns the output file path
- Recording tests verify actual file creation and content

### Comprehensive Integration Tests (20 tests)
- New `ObsIntegrationTests.cs` with full test coverage for all 7 MCP tools
- Tests require OBS running (marked with `[Trait("Category", "Integration")]`)
- File verification: screenshot and recording tests verify files are created with content

### Pre-commit Hook
- Added `scripts/pre-commit` (shell) and `scripts/pre-commit.ps1` (PowerShell)
- `scripts/install-hooks.ps1` to install the hook
- Hook runs all tests before allowing commits

### Test Infrastructure Fixes
- Fixed DotNetEnv not loading .env file (added `Env.TraversePath().Load()`)
- Integration tests now fail properly when OBS is not running (no silent skips)
- Updated copilot instructions with test requirements and git workflow

## Testing

- **46 total tests** (26 MCP protocol + 20 integration)
- All tests pass
- Tested manually with OBS Studio
